### PR TITLE
Override Changes for 0.15

### DIFF
--- a/angelsrefining_0.7.1/prototypes/override-functions.lua
+++ b/angelsrefining_0.7.1/prototypes/override-functions.lua
@@ -15,11 +15,13 @@ local function initialize_tables ()
 
    disable_table = {
       recipes = {},
+      hard_recipes = {},
       technologies = {}
    }
 
    modify_table = {
       recipes = {},
+      force_difficulty_split = {},
       technologies = {}
    }
 
@@ -77,19 +79,83 @@ ov_functions.set_special_technology_override = function (technology, t)
    override_table.technologies[technology] = t
 end
 
-ov_functions.set_input = function (recipe, item, i_type, amount)
+local function force_difficulty_split (recipe)
+   modify_table.force_difficulty_split[recipe] = true
+end
+
+local function set_normal_input (recipe, item, i_type, amount)
    guarantee_subtable(modify_table.recipes, recipe)
    guarantee_subtable(modify_table.recipes[recipe], "inputs")
    modify_table.recipes[recipe].inputs[item] = { type = i_type, amount = amount }
 end
 
-ov_functions.set_output = function (recipe, item, i_type, amount)
-   guarantee_subtable(modify_table.recipes, recipe)
-   guarantee_subtable(modify_table.recipes[recipe], "outputs")
-   modify_table.recipes[recipe].outputs[item] = { type = i_type, amount = amount }
+ov_functions.set_normal_input = function (recipe, item, i_type, amount)
+   set_normal_input(recipe, item, i_type, amount)
+   force_difficulty_split(recipe)
 end
 
-ov_functions.remove_input = function (recipe, item) -- remove item from input of recipe (item may be a table containing a list of items to remove)
+local function set_hard_input (recipe, item, i_type, amount)
+   guarantee_subtable(modify_table.recipes, recipe)
+   guarantee_subtable(modify_table.recipes[recipe], "hard")
+   guarantee_subtable(modify_table.recipes[recipe].hard, "inputs")
+   modify_table.recipes[recipe].hard.inputs[item] = { type = i_type, amount = amount }
+end
+
+ov_functions.set_hard_input = function (recipe, item, i_type, amount)
+   set_hard_input(recipe, item, i_type, amount)
+   force_difficulty_split(recipe)
+end
+
+ov_functions.set_input = function (recipe, item, i_type, amount)
+   set_normal_input(recipe, item, i_type, amount)
+   set_hard_input(recipe, item, i_type, amount)
+end
+
+local function set_normal_output (recipe, item, i_type, amount)
+   guarantee_subtable(modify_table.recipes, recipe)
+   guarantee_subtable(modify_table.recipes[recipe], "outputs")
+   if type(amount) == "table" then
+      if amount.amount and amount.probability then
+         modify_table.recipes[recipe].outputs[item] = { type = i_type, amount = amount.amount, probability = amount.probability }
+      elseif amount.amount_min and amount.amount_max and amount.probability then
+         modify_table.recipes[recipe].outputs[item] = { type = i_type, amount_min = amount.amount_min, amount_max = amount.amount_max, probability = amount.probability }
+      end
+   else
+      modify_table.recipes[recipe].outputs[item] = { type = i_type, amount = amount }
+   end
+end
+
+ov_functions.set_normal_output = function (recipe, item, i_type, amount) -- amount may be a table containing probability-related values
+   set_normal_output(recipe, item, i_type, amount)
+   force_difficulty_split(recipe)
+end
+
+local function set_hard_output (recipe, item, i_type, amount)
+   guarantee_subtable(modify_table.recipes, recipe)
+   guarantee_subtable(modify_table.recipes[recipe], "hard")
+   guarantee_subtable(modify_table.recipes[recipe].hard, "outputs")
+   if type(amount) == "table" then
+      if amount.amount and amount.probability then
+         modify_table.recipes[recipe].hard.outputs[item] = { type = i_type, amount = amount.amount, probability = amount.probability }
+      elseif amount.amount_min and amount.amount_max and amount.probability then
+         modify_table.recipes[recipe].hard.outputs[item] = { type = i_type, amount_min = amount.amount_min, amount_max = amount.amount_max, probability = amount.probability }
+      end
+   else
+      modify_table.recipes[recipe].hard.outputs[item] = { type = i_type, amount = amount }
+   end
+end
+
+ov_functions.set_hard_output = function (recipe, item, i_type, amount) -- amount may be a table containing probability-related values
+   set_hard_output(recipe, item, i_type, amount)
+   force_difficulty_split(recipe)
+end
+
+ov_functions.set_output = function (recipe, item, i_type, amount) -- amount may be a table containing probability-related values
+   set_normal_output(recipe, item, i_type, amount)
+   set_hard_output(recipe, item, i_type, amount)
+end
+
+local function remove_normal_input (recipe, item)
    if type(item) == "table" then
       for ik, it in pairs(item) do
          ov_functions.remove_input(recipe, it)
@@ -101,7 +167,35 @@ ov_functions.remove_input = function (recipe, item) -- remove item from input of
    end
 end
 
-ov_functions.remove_output = function (recipe, item) -- remove item from output of recipe (item may be a table containing a list of items to remove)
+ov_functions.remove_normal_input = function (recipe, item) -- remove item from input of recipe (item may be a table containing a list of items to remove)
+   remove_normal_input(recipe, item)
+   force_difficulty_split(recipe)
+end
+
+local function remove_hard_input (recipe, item)
+   if type(item) == "table" then
+      for ik, it in pairs(item) do
+         ov_functions.remove_input(recipe, it)
+      end
+   else
+      guarantee_subtable(modify_table.recipes, recipe)
+      guarantee_subtable(modify_table.recipes[recipe], "hard")
+      guarantee_subtable(modify_table.recipes[recipe].hard, "inputs")
+      modify_table.recipes[recipe].hard.inputs[item] = { amount = 0 }
+   end
+end
+
+ov_functions.remove_hard_input = function (recipe, item) -- remove item from input of recipe (item may be a table containing a list of items to remove)
+   remove_hard_input(recipe, item)
+   force_difficulty_split(recipe)
+end
+
+ov_functions.remove_input = function (recipe, item) -- remove item from input of recipe (item may be a table containing a list of items to remove)
+   remove_normal_input(recipe, item)
+   remove_hard_input(recipe, item)
+end
+
+local function remove_normal_output (recipe, item)
    if type(item) == "table" then
       for ik, it in pairs(item) do
          ov_functions.remove_output(recipe, it)
@@ -111,6 +205,34 @@ ov_functions.remove_output = function (recipe, item) -- remove item from output 
       guarantee_subtable(modify_table.recipes[recipe], "outputs")
       modify_table.recipes[recipe].outputs[item] = { amount = 0 }
    end
+end
+
+ov_functions.remove_normal_output = function (recipe, item) -- remove item from output of recipe (item may be a table containing a list of items to remove)
+   remove_normal_output(recipe, item)
+   force_difficulty_split(recipe)
+end
+
+local function remove_hard_output (recipe, item)
+   if type(item) == "table" then
+      for ik, it in pairs(item) do
+         ov_functions.remove_output(recipe, it)
+      end
+   else
+      guarantee_subtable(modify_table.recipes, recipe)
+      guarantee_subtable(modify_table.recipes[recipe], "hard")
+      guarantee_subtable(modify_table.recipes[recipe].hard, "outputs")
+      modify_table.recipes[recipe].hard.outputs[item] = { amount = 0 }
+   end
+end
+
+ov_functions.remove_hard_output = function (recipe, item) -- remove item from output of recipe (item may be a table containing a list of items to remove)
+   remove_hard_output(recipe, item)
+   force_difficulty_split(recipe)
+end
+
+ov_functions.remove_output = function (recipe, item) -- remove item from output of recipe (item may be a table containing a list of items to remove)
+   remove_normal_output(recipe, item)
+   remove_hard_output(recipe, item)
 end
 
 ov_functions.replace_item = function (recipe, old, new) -- replace all occurrences of old with new in recipe (recipe may be a table containing a list of recipes)
@@ -149,7 +271,7 @@ ov_functions.hide_recipe = function (recipe) -- hides recipe (may be a table con
    end
 end
 
-ov_functions.disable_recipe = function (recipe) -- disables recipe (may be a table containing a list of recipes)
+local function disable_normal_recipe (recipe)
    if type(recipe) == "table" then
       for rk, rec in pairs(recipe) do
          disable_table.recipes[rec] = true
@@ -157,6 +279,31 @@ ov_functions.disable_recipe = function (recipe) -- disables recipe (may be a tab
    else
       disable_table.recipes[recipe] = true
    end
+end
+
+ov_functions.disable_normal_recipe = function (recipe) -- disables recipe (may be a table containing a list of recipes)
+   disable_normal_recipe(recipe)
+   force_difficulty_split(recipe)
+end
+
+local function disable_hard_recipe (recipe)
+   if type(recipe) == "table" then
+      for rk, rec in pairs(recipe) do
+         disable_table.hard_recipes[rec] = true
+      end
+   else
+      disable_table.hard_recipes[recipe] = true
+   end
+end
+
+ov_functions.disable_hard_recipe = function (recipe) -- disables recipe (may be a table containing a list of recipes)
+   disable_hard_recipe(recipe)
+   force_difficulty_split(recipe)
+end
+
+ov_functions.disable_recipe = function (recipe) -- disables recipe (may be a table containing a list of recipes)
+   disable_normal_recipe(recipe)
+   disable_hard_recipe(recipe)
 end
 
 ov_functions.set_special_recipe_override = function (recipe, t)
@@ -211,17 +358,41 @@ end
 
 -- OVERRIDE EXECUTION
 
+local function d_c (t)
+   if type(t) == "table" then
+      local result = {}
+      for k, v in pairs(t) do
+         result[k] = d_c(t[k])
+      end
+      return result
+   else
+      return t
+   end
+end
+
+local function split_recipe_difficulty (recipe)
+   recipe.normal = { ingredients = d_c(recipe.ingredients), result = recipe.result, result_count = recipe.result_count, results = d_c(recipe.results), enabled = recipe.enabled, energy_required = recipe.energy_required }
+   recipe.expensive = { ingredients = d_c(recipe.ingredients), result = recipe.result, result_count = recipe.result_count, results = d_c(recipe.results), enabled = recipe.enabled, energy_required = recipe.energy_required }
+   recipe.ingredients = nil
+   recipe.result = nil
+   recipe.result_count = nil
+   recipe.results = nil
+   recipe.enabled = nil
+   recipe.energy_required = nil
+end
+
 local function adjust_recipe (recipe, k) -- check a recipe for basic adjustments based on tables and make any necessary changes
-   local function adjust_member (member, substitution_type)
-      if recipe[member] then
-         local new = substitution_table[substitution_type][recipe[member]]
+   local function adjust_member (parent, member, substitution_type)
+      local old = parent[member]
+      if old then
+         local new = substitution_table[substitution_type][old]
          if new then
-            recipe[member] = new
+            parent[member] = new
          end
       end
    end
-   local function adjust_subtable (subtable, substitution_type)
-      local st = recipe[subtable]
+   local function adjust_subtable (parent, subtable, substitution_type)
+      local st = parent[subtable]
       if st then
          for ix, item in pairs(st) do
             if not item.name then -- shift to uniform format for ease of handling
@@ -231,23 +402,116 @@ local function adjust_recipe (recipe, k) -- check a recipe for basic adjustments
                item[1] = nil
                item[2] = nil
             end
-            local new = substitution_table[substitution_type][item.name or item[1]]
+            local new = substitution_table[substitution_type][item.name]
             if new then
-               if item.name then
-                  item.name = new
+               item.name = new
+            end
+         end
+      end
+   end
+   local function adjust_difficulty (path)
+      adjust_subtable(path, "ingredients", "recipe_items")
+      adjust_member(path, "result", "recipe_items")
+      adjust_subtable(path, "results", "recipe_items")
+   end
+   if recipe.category ~= "angels-converter" then -- leave converter recipes alone so we can still use them if necessary
+      if recipe.normal or recipe.expensive then
+         adjust_difficulty(recipe.normal)
+         adjust_difficulty(recipe.expensive)
+      else
+         adjust_difficulty(recipe)
+      end
+      adjust_member(recipe, "main_product", "recipe_items")
+      adjust_member(recipe, "icon", "recipe_icons")
+   end
+end
+
+local function modify_recipe (recipe, modifications)
+   local function modify_difficulty (path, mod_path)
+      local to_remove = {}
+      for ik, input in pairs(path.ingredients) do
+         if mod_path and mod_path.inputs and mod_path.inputs[input.name] then
+            if mod_path.inputs[input.name].amount == 0 then
+               to_remove[ik] = true
+            else
+               input.amount = mod_path.inputs[input.name].amount
+            end
+            mod_path.inputs[input.name] = nil
+         end
+         if modifications.substitutions and modifications.substitutions[input.name] and not to_remove[ik] then
+            input.name = modifications.substitutions[input.name]
+         end
+      end
+      for ik = #path.ingredients, 1, -1 do
+         if to_remove[ik] then
+            table.remove(path.ingredients, ik)
+         end
+      end
+      if mod_path and mod_path.inputs then
+         for item, info in pairs(mod_path.inputs) do
+            if info.amount > 0 then
+               table.insert(path.ingredients, { name = item, type = info.type, amount = info.amount })
+            end
+         end
+      end
+      if path.results then
+         to_remove = {}
+         for ok, output in pairs(path.results) do
+            if mod_path and mod_path.outputs and mod_path.outputs[output.name] then
+               if mod_path.outputs[output.name].amount == 0 then
+                  to_remove[ok] = true
                else
-                  item[1] = new
+                  path.results[ok].amount = mod_path.outputs[output.name].amount
+               end
+               mod_path.outputs[output.name] = nil
+            end
+            if modifications.substitutions and modifications.substitutions[output.name] and not to_remove[ok] then
+               output.name = modifications.substitutions[output.name]
+            end
+         end
+         for ok = #path.results, 1, -1 do
+            if to_remove[ok] then
+               table.remove(path.results, ok)
+            end
+         end
+         if mod_path and mod_path.outputs then
+            for item, info in pairs(mod_path.outputs) do
+               if not info.amount or info.amount > 0 then
+                  table.insert(path.results, { name = item, type = info.type, amount = info.amount, amount_min = info.amount_min, amount_max = info.amount_max, probability = info.probability })
+               end
+            end
+         end
+      elseif path.result then
+         if mod_path and mod_path.outputs and mod_path.outputs[path.result] then
+            path.result_count = mod_path.outputs[path.result].amount
+            mod_path.outputs[path.result] = nil
+         end
+         if modifications.substitutions and modifications.substitutions[path.result] then
+            path.result = modifications.substitutions[path.result]
+         end
+         if mod_path and mod_path.outputs and next(mod_path.outputs) then -- transition from one output to multiple
+            recipe.main_product = path.result
+            path.results = { { name = path.result, type = "item", amount = path.result_count } }
+            path.result = nil
+            path.result_count = nil
+            for item, info in pairs(mod_path.outputs) do
+               if not info.amount or info.amount > 0 then
+                  table.insert(path.results, { name = item, type = info.type, amount = info.amount, amount_min = info.amount_min, amount_max = info.amount_max, probability = info.probability })
                end
             end
          end
       end
    end
-   if recipe.category ~= "angels-converter" then -- leave converter recipes alone so we can still use them if necessary
-      adjust_subtable("ingredients", "recipe_items")
-      adjust_member("result", "recipe_items")
-      adjust_subtable("results", "recipe_items")
-      adjust_member("main_product", "recipe_items")
-      adjust_member("icon", "recipe_icons")
+   if modifications then
+      if modifications.substitutions and recipe.main_product and modifications.substitutions[recipe.main_product] then
+         recipe.main_product = modifications.substitutions[recipe.main_product]
+      end
+      if recipe.normal or recipe.expensive then
+         modify_difficulty(recipe.normal, modifications)
+         modify_difficulty(recipe.expensive, modifications.hard)
+      else
+         modify_difficulty(recipe, modifications)
+      end
    end
 end
 
@@ -270,93 +534,27 @@ end
 
 ov_functions.execute = function ()
    for k, recipe in pairs(data.raw.recipe) do -- run through all recipes to perform substitutions/overrides
-      if disable_table.recipes[k] then
-         recipe.enabled = false
-      else
-       if hide_table[k] then
-         recipe.hidden = true
-       end
-         adjust_recipe(recipe, k)
-         local modifications = modify_table.recipes[k]
-         if modifications then
-            local to_remove = {}
-            for ik, input in pairs(recipe.ingredients) do
-               if modifications.inputs and modifications.inputs[input.name] then
-                  if modifications.inputs[input.name].amount == 0 then
-                     to_remove[ik] = true
-                  else
-                     input.amount = modifications.inputs[input.name].amount
-                  end
-                  modifications.inputs[input.name] = nil
-               end
-               if modifications.substitutions and modifications.substitutions[input.name] and not to_remove[ik] then
-                  input.name = modifications.substitutions[input.name]
-               end
-            end
-            for ik = #recipe.ingredients, 1, -1 do
-               if to_remove[ik] then
-                  table.remove(recipe.ingredients, ik)
-               end
-            end
-            if modifications.inputs then
-               for item, info in pairs(modifications.inputs) do
-                  if info.amount > 0 then
-                     table.insert(recipe.ingredients, { name = item, type = info.type, amount = info.amount })
-                  end
-               end
-            end
-            if recipe.results then
-               to_remove = {}
-               for ok, output in pairs(recipe.results) do
-                  if modifications.outputs and modifications.outputs[output.name] then
-                     if modifications.outputs[output.name].amount == 0 then
-                        to_remove[ok] = true
-                     else
-                        recipe.results[ok].amount = modifications.outputs[output.name].amount
-                     end
-                     modifications.outputs[output.name] = nil
-                  end
-                  if modifications.substitutions and modifications.substitutions[output.name] and not to_remove[ok] then
-                     output.name = modifications.substitutions[output.name]
-                  end
-               end
-               for ok = #recipe.results, 1, -1 do
-                  if to_remove[ok] then
-                     table.remove(recipe.results, ok)
-                  end
-               end
-               if modifications.outputs then
-                  for item, info in pairs(modifications.outputs) do
-                     if info.amount > 0 then
-                        table.insert(recipe.results, { name = item, type = info.type, amount = info.amount })
-                     end
-                  end
-               end
-               if modifications.substitutions then
-                  recipe.main_product = modifications.substitutions[recipe.main_product]
-               end
-            elseif recipe.result then
-               if modifications.outputs and modifications.outputs[recipe.result] then
-                  recipe.result_count = modifications.outputs[recipe.result].amount
-                  modifications.outputs[recipe.result] = nil
-               end
-               if modifications.substitutions and modifications.substitutions[recipe.result] then
-                  recipe.result = modifications.substitutions[recipe.result]
-               end
-               if modifications.outputs and next(modifications.outputs) then -- transition from one output to multiple
-                  recipe.main_product = recipe.result
-                  recipe.results = { { name = recipe.result, type = "item", amount = recipe.result_count } }
-                  recipe.result = nil
-                  recipe.result_count = nil
-                  for item, info in pairs(modifications.outputs) do
-                     if info.amount > 0 then
-                        table.insert(recipe.results, { name = item, type = info.type, amount = info.amount })
-                     end
-                  end
-               end
-            end
-            
+      if disable_table.recipes[k] and disable_table.hard_recipes[k] then
+         if recipe.normal then
+            recipe.normal.enabled = false
+            recipe.expensive.enabled = false
+         else
+            recipe.enabled = false
          end
+      else
+         if modify_table.force_difficulty_split[k] and not recipe.normal then
+            split_recipe_difficulty(recipe)
+         end
+         if disable_table.recipes[k] then
+            recipe.normal.enabled = false
+         elseif disable_table.hard_recipes[k] then
+            recipe.expensive.enabled = false
+         end
+         if hide_table[k] then
+            recipe.hidden = true
+         end
+         adjust_recipe(recipe, k)
+         modify_recipe(recipe, modify_table.recipes[k])
          local overrides = override_table.recipes[k]
          if overrides then
             override_subtable(recipe, overrides)


### PR DESCRIPTION
Fixed handling of override functions for difficulty tiers.
Relevant functions split up (e.g. set_output now has set_output, set_normal_output, and set_hard_output variants).
  -Using _normal_ or _hard_ variant of functions on a recipe with old-style format should automatically split the recipe into normal and expensive versions before applying changes.
Handling for probabilities in set_output functions added.